### PR TITLE
Fix issue with tailwind class escaping

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -9,14 +9,14 @@
 const buildSuffixMap = (configObj, e, sep = '-') => {
   const build = (obj, prefix = '') => Object.entries(obj)
     .reduce((memo, [key, value]) => {
-      const suffix = `${sep}${e(key)}`;
+      const suffix = `${sep}${key}`;
       let result;
 
       if (typeof value === 'object') {
         result = build(value, suffix);
       } else {
         const compoundKey = key === 'DEFAULT' ? prefix : `${prefix}${suffix}`;
-        result = { [compoundKey]: value };
+        result = { [e(compoundKey)]: value };
       }
 
       return { ...memo, ...result };


### PR DESCRIPTION
`tailwind.e` was being used incorrectly, causing classnames to be incorrectly escaped. This caused `@apply` to not work. I believe this is what causes #25

See below for the generated css:
![image](https://user-images.githubusercontent.com/15876682/145305869-865be200-3719-451a-9710-8f192a1be13f.png)

The input for `tailwind.e` needs to be the whole class name. Prior to this PR, the input was only the colour modifier (100, 200, 300, ect). As classnames cannot begin with a number, this gets escaped.