### PR TITLE
Update variants to read from correct path in Tailwind 3.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const { scrollbarAwareHover } = require('./variants');
 const CUSTOM_VARIANTS = ['rounded'];
 
 module.exports = plugin(tailwind => {
-  const scrollbarVariants = tailwind.variants('scrollbar', []);
+  const scrollbarVariants = tailwind.config('variants.scrollbar', []);
 
   const scrollbarColorUtilities = generateUtilitiesFromSuffixes(
     buildSuffixMap(tailwind.theme('colors', {}), tailwind.e),


### PR DESCRIPTION
As per suggestion from https://github.com/adoxography/tailwind-scrollbar/issues/35#issuecomment-1050724217. The variants has changed in Tailwind 3.x, and as such needs this change to read the value of the variants array.