### PR TITLE
fix: fixing deprecated overflow-overlay

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -32,9 +32,9 @@ const SCROLLBAR_SIZE_BASE = {
 
   'scrollbar-color': 'var(--scrollbar-thumb) var(--scrollbar-track)',
 
-  // Make sure the scrollbars are calculated in the elements width
-  // TODO: Retrace why this was included - firefox compatibility, maybe?
-  overflow: 'overlay',
+  //sets the desired behavior for an element's overflow to be visible
+  overflow: 'auto',
+  
 
   // Prevent the plugin from overriding overflow-hidden
   '&.overflow-x-hidden': {


### PR DESCRIPTION
This fixes the scrollbar from always being the topmost element even when some elements have a higher z-index 
Example of a sidebar collapse button positioned absolute.
as shown from the following pictures .


**before**
![Screenshot 2023-01-11 at 16 33 49](https://user-images.githubusercontent.com/39158826/211819510-a3f65b1d-4d03-4ade-9f05-872ccc91b56f.png)

**after**
![Screenshot 2023-01-11 at 16 35 37](https://user-images.githubusercontent.com/39158826/211819837-1e416b83-c1f9-4e01-9d9a-0d6b0ed9e086.png)

