### PR TITLE
Remove deprecated rounded variant

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,26 +9,13 @@ const {
 const { addVariantOverrides } = require('./variants');
 
 module.exports = plugin.withOptions((options = {}) => tailwind => {
-  const areRoundedVariantsSpecified = () => {
-    if (tailwind.config('variants.scrollbar', []).includes('rounded')) {
-      /* eslint-disable-next-line no-console */
-      console.log('DEPRECATION: adding rounded classes via the variants array is deprecated. Use nocompatible mode instead (i.e. when adding the plugin, use `scrollbarPlugin({ nocompatible: true })`)');
-      return true;
-    }
-
-    return false;
-  };
-
   tailwind.addBase(BASE_STYLES);
   tailwind.addUtilities(SCROLLBAR_SIZE_UTILITIES);
   addColorUtilities(tailwind);
   addVariantOverrides(tailwind);
 
-  if (options.nocompatible || areRoundedVariantsSpecified()) {
-    addRoundedUtilities(tailwind);
-  }
-
   if (options.nocompatible) {
+    addRoundedUtilities(tailwind);
     addSizeUtilities(tailwind);
   }
 });

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -583,32 +583,6 @@ test('it generates rounded states in nocompatible mode', async () => {
 `);
 });
 
-test('it generates rounded states when "rounded" is specified as a variant', async () => {
-  // Deprecated
-  const css = await generatePluginCss({
-    theme: {
-      borderRadius: {
-        DEFAULT: '0.25rem',
-        md: '0.375rem'
-      }
-    },
-    variants: {
-      scrollbar: ['rounded']
-    },
-    content: [{
-      raw: `
-        <div class="scrollbar-thumb-rounded" />
-      `
-    }]
-  });
-
-  expect(css).toMatchInlineSnapshot(`
-    ".scrollbar-thumb-rounded {
-        --scrollbar-thumb-radius: 0.25rem
-    }"
-`);
-});
-
 test('it does not generate width utilties in nocompatible mode', async () => {
   const css = await generatePluginCss({
     theme: {


### PR DESCRIPTION
The next release will be a major version, so it's appropriate to remove the deprecated `rounded` variant flag.