### PR TITLE
Ensure variant order is preserved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwind-scrollbar",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwind-scrollbar",
-      "version": "2.1.0",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "cross-env": "^7.0.3",

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -1,4 +1,4 @@
-const { generatePluginCss } = require('./util');
+const { generatePluginCss, generateTailwindCss } = require('./util');
 
 test('it generates .scrollbar utilities', async () => {
   const css = await generatePluginCss({
@@ -647,4 +647,17 @@ test('it does not generate rounded states when not in nocompatible mode', async 
   });
 
   expect(css).toBe('');
+});
+
+test('it preserves the order of variants', async () => {
+  const content = [{
+    raw: `
+      <button class="hover:bg-black active:bg-black focus:bg-black focus-within:bg-black focus-visible:bg-black disabled:bg-black" />
+    `
+  }];
+
+  const pluginCss = await generatePluginCss({ content });
+  const normalCss = await generateTailwindCss({ content });
+
+  expect(pluginCss).toBe(normalCss);
 });

--- a/test/util.js
+++ b/test/util.js
@@ -5,6 +5,23 @@ const tailwindcss = require('tailwindcss');
 const scrollbarPlugin = require('..');
 
 /**
+ * Runs a config through tailwind
+ *
+ * @see https://www.oliverdavies.uk/blog/testing-tailwind-css-plugins-jest
+ * @param {object} config Tailwind config options to pass to tailwind
+ * @returns {Promise<string>} The CSS generated using the provided config
+ */
+const generateTailwindCss = async (config = {}) => {
+  const { currentTestName } = expect.getState();
+
+  const result = await postcss(tailwindcss(config))
+    .process('@tailwind utilities;', {
+      from: `${path.resolve(__filename)}?test=${currentTestName}`
+    });
+
+  return result.css;
+};
+/**
  * Generates the CSS for the plugin
  *
  * @see https://www.oliverdavies.uk/blog/testing-tailwind-css-plugins-jest
@@ -17,16 +34,10 @@ const generatePluginCss = async (config = {}, options = {}) => {
     plugins: [scrollbarPlugin(options)]
   }, config);
 
-  const { currentTestName } = expect.getState();
-
-  const result = await postcss(tailwindcss(tailwindConfig))
-    .process('@tailwind utilities;', {
-      from: `${path.resolve(__filename)}?test=${currentTestName}`
-    });
-
-  return result.css;
+  return generateTailwindCss(tailwindConfig);
 };
 
 module.exports = {
+  generateTailwindCss,
   generatePluginCss
 };


### PR DESCRIPTION
While mucking with the internal PostCSS to make the `::-webkit-scrollbar-*` pseudoelements behave themselves, the order of those rules gets changed. Resolution is to touch all of the variants from `hover` on so that the relative order is preserved.

Addresses #71 

(See Tailwind's [canonical ordering](https://github.com/tailwindlabs/tailwindcss/blob/4893cad29c581d5e557f75ebad999d8f343d61b4/src/corePlugins.js#L130))