### PR TITLE
Explicity set ::-webkit-scrollbar to display: block

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -49,6 +49,7 @@ const SCROLLBAR_SIZE_UTILITIES = {
     'scrollbar-width': 'auto',
 
     '&::-webkit-scrollbar': {
+      display: 'block',
       width: 'var(--scrollbar-width, 16px)',
       height: 'var(--scrollbar-height, 16px)'
     }
@@ -59,6 +60,7 @@ const SCROLLBAR_SIZE_UTILITIES = {
     'scrollbar-width': 'thin',
 
     '&::-webkit-scrollbar': {
+      display: 'block',
       width: '8px',
       height: '8px'
     }

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -47,6 +47,7 @@ test('it generates .scrollbar utilities', async () => {
         scrollbar-width: auto;
     }
     .scrollbar::-webkit-scrollbar {
+        display: block;
         width: var(--scrollbar-width, 16px);
         height: var(--scrollbar-height, 16px);
     }"
@@ -100,6 +101,7 @@ test('it generates .scrollbar-thin utilities', async () => {
         scrollbar-width: thin;
     }
     .scrollbar-thin::-webkit-scrollbar {
+        display: block;
         width: 8px;
         height: 8px;
     }"


### PR DESCRIPTION
Addresses #70. In my own testing, it looks like `!important` isn't required to work alongside DaisyUI (presumably because scrollbar classes are registered as utilities, which are declared after components in standard Tailwind). Shouldn't cause any issues because `block` is the default display value, and if you're setting a scrollbar utility, it's a fair assumption that you want to see your scrollbar.