### PR TITLE
Check for CommonJS imports

### DIFF
--- a/src/helpers.d.ts
+++ b/src/helpers.d.ts
@@ -1,0 +1,14 @@
+/**
+ * Imports a default export agnostic of whether CommonJS is in use or not.
+ *
+ * This is used to handle internal imoprts from Tailwind, since Tailwind Play
+ * handles these imports differently.
+ *
+ * This is a hacky fix to get this working; in particular, it makes the typing
+ * very loose. Converting the entire module to typescript might have the side
+ * effect of making this function unnecessary.
+ *
+ * @param {string} path The path to import
+ * @returns {unknown} The imported module
+ */
+export function agnosticRequire(path: string): unknown;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,23 @@
+/**
+ * Imports a default export agnostic of whether CommonJS is in use or not.
+ *
+ * This is used to handle internal imoprts from Tailwind, since Tailwind Play
+ * handles these imports differently.
+ *
+ * This is a hacky fix to get this working; in particular, it makes the typing
+ * very loose. Converting the entire module to typescript might have the side
+ * effect of making this function unnecessary.
+ *
+ * @param {string} path The path to import
+ * @returns {unknown} The imported module
+ */
+const agnosticRequire = path => {
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  const exported = require(path);
+  // eslint-disable-next-line no-underscore-dangle
+  return exported.__esModule && exported.default ? exported.default : exported;
+};
+
+module.exports = {
+  agnosticRequire
+};

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,6 +1,8 @@
-const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette');
-const toColorValue = require('tailwindcss/lib/util/toColorValue');
 const typedefs = require('./typedefs');
+const { agnosticRequire } = require('./helpers');
+
+const flattenColorPalette = agnosticRequire('tailwindcss/lib/util/flattenColorPalette');
+const toColorValue = agnosticRequire('tailwindcss/lib/util/toColorValue');
 
 const COMPONENTS = ['track', 'thumb', 'corner'];
 
@@ -81,16 +83,16 @@ const SCROLLBAR_SIZE_UTILITIES = {
  * @param {typedefs.TailwindPlugin} tailwind - Tailwind's plugin object
  */
 const addColorUtilities = ({ matchUtilities, theme }) => {
-  const themeColors = flattenColorPalette.default(theme('colors'));
+  const themeColors = flattenColorPalette(theme('colors'));
   const colors = Object.fromEntries(
-    Object.entries(themeColors).map(([k, v]) => [k, toColorValue.default(v)])
+    Object.entries(themeColors).map(([k, v]) => [k, toColorValue(v)])
   );
 
   COMPONENTS.forEach(component => {
     matchUtilities(
       {
         [`scrollbar-${component}`]: value => {
-          const color = toColorValue.default(value);
+          const color = toColorValue(value);
           return {
             [`--scrollbar-${component}`]: `${color} !important`
           };


### PR DESCRIPTION
Guesswork here - Tailwind Play is crashing saying that `h.default` is not a function. (See #75.) Assumption is that the internal tailwind imports are treated as CommonJS in typical flows (which assigns the default import to `default`), but within Tailwind Play, they're coming as ES6 imports.

Tests are still passing so it shouldn't break any workflows, but will have to publish to test if it fixes the Tailwind Play issue.