### PR TITLE
Bugfix/tailwind play support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,5 +34,10 @@ module.exports = {
         ArrowFunctionExpression: true
       }
     }]
+  },
+  settings: {
+    jsdoc: {
+      mode: 'typescript'
+    }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwind-scrollbar",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwind-scrollbar",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT",
       "devDependencies": {
         "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-scrollbar",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Tailwind plugin for styling scrollbars",
   "author": "Graham Still <graham@gstill.dev>",
   "main": "src/index.js",

--- a/src/helpers.d.ts
+++ b/src/helpers.d.ts
@@ -1,14 +1,14 @@
 /**
- * Imports a default export agnostic of whether CommonJS is in use or not.
+ * Gets the underlying default import of a module.
  *
  * This is used to handle internal imoprts from Tailwind, since Tailwind Play
  * handles these imports differently.
  *
- * This is a hacky fix to get this working; in particular, it makes the typing
- * very loose. Converting the entire module to typescript might have the side
- * effect of making this function unnecessary.
- *
- * @param {string} path The path to import
- * @returns {unknown} The imported module
+ * @template T
+ * @param {T | { __esModule: unknown, default: T }} mod The module
+ * @returns {T} The bare export
  */
-export function agnosticRequire(path: string): unknown;
+export function importDefault<T>(mod: T | {
+    __esModule: unknown;
+    default: T;
+}): T;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,23 +1,16 @@
 /**
- * Imports a default export agnostic of whether CommonJS is in use or not.
+ * Gets the underlying default import of a module.
  *
  * This is used to handle internal imoprts from Tailwind, since Tailwind Play
  * handles these imports differently.
  *
- * This is a hacky fix to get this working; in particular, it makes the typing
- * very loose. Converting the entire module to typescript might have the side
- * effect of making this function unnecessary.
- *
- * @param {string} path The path to import
- * @returns {unknown} The imported module
+ * @template T
+ * @param {T | { __esModule: unknown, default: T }} mod The module
+ * @returns {T} The bare export
  */
-const agnosticRequire = path => {
-  // eslint-disable-next-line global-require, import/no-dynamic-require
-  const exported = require(path);
-  // eslint-disable-next-line no-underscore-dangle
-  return exported.__esModule && exported.default ? exported.default : exported;
-};
+// eslint-disable-next-line no-underscore-dangle
+const importDefault = mod => (mod?.__esModule ? mod.default : mod);
 
 module.exports = {
-  agnosticRequire
+  importDefault
 };

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,8 +1,12 @@
+const flattenColorPaletteImport = require('tailwindcss/lib/util/flattenColorPalette');
+const toColorValueImport = require('tailwindcss/lib/util/toColorValue');
 const typedefs = require('./typedefs');
-const { agnosticRequire } = require('./helpers');
+const { importDefault } = require('./helpers');
 
-const flattenColorPalette = agnosticRequire('tailwindcss/lib/util/flattenColorPalette');
-const toColorValue = agnosticRequire('tailwindcss/lib/util/toColorValue');
+// Tailwind Play will import these internal imports as ES6 imports, while most
+// other workflows will import them as CommonJS imports.
+const flattenColorPalette = importDefault(flattenColorPaletteImport);
+const toColorValue = importDefault(toColorValueImport);
 
 const COMPONENTS = ['track', 'thumb', 'corner'];
 


### PR DESCRIPTION
#76 used a dynamic import, which causes a different crash on Tailwind Play, since it looks like it's using Rollup and that (apparently) can't handle dynamic requires.