### PR TITLE
Feature/preferred strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 `tailwind-scrollbar` is a plugin for [Tailwind CSS](https://tailwindcss.com) that adds styling utilities for scrollbars with cross-browser support.
 
 ## Motivation
-There are currently two competing standards for styling scrollbars amongst browsers: the [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) and [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) properties used by Firefox and the [::-webkit-scrollbar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) family of pseudoelements used by everything else\*. This plugin defines a single API for configuring both standards at once from within Tailwind.
+There are currently two competing standards for styling scrollbars amongst browsers: the [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) and [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) properties used by Firefox and newer Chromium-based browsers, and the [::-webkit-scrollbar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) family of pseudoelements used by everything else. This plugin defines a single API for configuring both standards at once from within Tailwind.
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tailwind-scrollbar",
-  "version": "3.0.5",
+  "version": "3.1.0-rc.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tailwind-scrollbar",
-      "version": "3.0.5",
+      "version": "3.1.0-rc.0",
       "license": "MIT",
       "devDependencies": {
         "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-scrollbar",
-  "version": "3.0.5",
+  "version": "3.1.0-rc.0",
   "description": "Tailwind plugin for styling scrollbars",
   "author": "Graham Still <graham@gstill.dev>",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const plugin = require('tailwindcss/plugin');
 const {
-  BASE_STYLES,
-  SCROLLBAR_SIZE_UTILITIES,
+  addBaseStyles,
+  addBaseSizeUtilities,
   addColorUtilities,
   addRoundedUtilities,
   addSizeUtilities
@@ -9,8 +9,16 @@ const {
 const { addVariantOverrides } = require('./variants');
 
 module.exports = plugin.withOptions((options = {}) => tailwind => {
-  tailwind.addBase(BASE_STYLES);
-  tailwind.addUtilities(SCROLLBAR_SIZE_UTILITIES);
+  let preferredStrategy = options.preferredStrategy ?? 'standard';
+
+  if (preferredStrategy !== 'standard' && preferredStrategy !== 'pseudoelements') {
+    // eslint-disable-next-line no-console
+    console.warn('WARNING: tailwind-scrollbar preferredStrategy should be \'standard\' or \'pseudoelements\'');
+    preferredStrategy = 'standard';
+  }
+
+  addBaseStyles(tailwind, preferredStrategy);
+  addBaseSizeUtilities(tailwind, preferredStrategy);
   addColorUtilities(tailwind);
   addVariantOverrides(tailwind);
 

--- a/src/utilities.d.ts
+++ b/src/utilities.d.ts
@@ -1,26 +1,17 @@
 /**
  * Base resets to make the plugin's utilities work
+ *
+ * @param {typedefs.TailwindPlugin} tailwind - Tailwind's plugin object
+ * @param {'standard' | 'peseudoelements'} preferredStrategy - The preferred
+ *    scrollbar styling strategy: standards track or pseudoelements
  */
-export const BASE_STYLES: {
-    '*': {
-        'scrollbar-color': string;
-        'scrollbar-width': string;
-    };
-};
+export function addBaseStyles({ addBase }: typedefs.TailwindPlugin, preferredStrategy: 'standard' | 'peseudoelements'): void;
 /**
- * Utilities for initializing a custom styled scrollbar, which implicitly set
- * the scrollbar's size
+ * @param {typedefs.TailwindPlugin} tailwind - Tailwind's plugin object
+ * @param {'standard' | 'peseudoelements'} preferredStrategy - The preferred
+ *    scrollbar styling strategy: standards track or pseudoelements
  */
-export const SCROLLBAR_SIZE_UTILITIES: {
-    '.scrollbar': any;
-    '.scrollbar-thin': any;
-    '.scrollbar-none': {
-        'scrollbar-width': string;
-        '&::-webkit-scrollbar': {
-            display: string;
-        };
-    };
-};
+export function addBaseSizeUtilities({ addUtilities }: typedefs.TailwindPlugin, preferredStrategy: 'standard' | 'peseudoelements'): void;
 /**
  * Adds scrollbar-COMPONENT-COLOR utilities for every scrollbar component.
  *

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -10,46 +10,44 @@ test('it generates .scrollbar utilities', async () => {
   });
 
   expect(css).toMatchInlineSnapshot(`
-    ".scrollbar {
-        scrollbar-color: var(--scrollbar-thumb, initial) var(--scrollbar-track, initial);
-    }
-    .scrollbar::-webkit-scrollbar-track {
+    ".scrollbar::-webkit-scrollbar-track {
         background-color: var(--scrollbar-track);
-        border-radius: var(--scrollbar-track-radius);
+        border-radius: var(--scrollbar-track-radius)
     }
     .scrollbar::-webkit-scrollbar-track:hover {
-        background-color: var(--scrollbar-track-hover, var(--scrollbar-track));
+        background-color: var(--scrollbar-track-hover, var(--scrollbar-track))
     }
     .scrollbar::-webkit-scrollbar-track:active {
-        background-color: var(--scrollbar-track-active, var(--scrollbar-track-hover, var(--scrollbar-track)));
+        background-color: var(--scrollbar-track-active, var(--scrollbar-track-hover, var(--scrollbar-track)))
     }
     .scrollbar::-webkit-scrollbar-thumb {
         background-color: var(--scrollbar-thumb);
-        border-radius: var(--scrollbar-thumb-radius);
+        border-radius: var(--scrollbar-thumb-radius)
     }
     .scrollbar::-webkit-scrollbar-thumb:hover {
-        background-color: var(--scrollbar-thumb-hover, var(--scrollbar-thumb));
+        background-color: var(--scrollbar-thumb-hover, var(--scrollbar-thumb))
     }
     .scrollbar::-webkit-scrollbar-thumb:active {
-        background-color: var(--scrollbar-thumb-active, var(--scrollbar-thumb-hover, var(--scrollbar-thumb)));
+        background-color: var(--scrollbar-thumb-active, var(--scrollbar-thumb-hover, var(--scrollbar-thumb)))
     }
     .scrollbar::-webkit-scrollbar-corner {
         background-color: var(--scrollbar-corner);
-        border-radius: var(--scrollbar-corner-radius);
+        border-radius: var(--scrollbar-corner-radius)
     }
     .scrollbar::-webkit-scrollbar-corner:hover {
-        background-color: var(--scrollbar-corner-hover, var(--scrollbar-corner));
+        background-color: var(--scrollbar-corner-hover, var(--scrollbar-corner))
     }
     .scrollbar::-webkit-scrollbar-corner:active {
-        background-color: var(--scrollbar-corner-active, var(--scrollbar-corner-hover, var(--scrollbar-corner)));
+        background-color: var(--scrollbar-corner-active, var(--scrollbar-corner-hover, var(--scrollbar-corner)))
     }
     .scrollbar {
         scrollbar-width: auto;
+        scrollbar-color: var(--scrollbar-thumb, initial) var(--scrollbar-track, initial)
     }
     .scrollbar::-webkit-scrollbar {
         display: block;
         width: var(--scrollbar-width, 16px);
-        height: var(--scrollbar-height, 16px);
+        height: var(--scrollbar-height, 16px)
     }"
   `);
 });
@@ -64,46 +62,44 @@ test('it generates .scrollbar-thin utilities', async () => {
   });
 
   expect(css).toMatchInlineSnapshot(`
-    ".scrollbar-thin {
-        scrollbar-color: var(--scrollbar-thumb, initial) var(--scrollbar-track, initial);
-    }
-    .scrollbar-thin::-webkit-scrollbar-track {
+    ".scrollbar-thin::-webkit-scrollbar-track {
         background-color: var(--scrollbar-track);
-        border-radius: var(--scrollbar-track-radius);
+        border-radius: var(--scrollbar-track-radius)
     }
     .scrollbar-thin::-webkit-scrollbar-track:hover {
-        background-color: var(--scrollbar-track-hover, var(--scrollbar-track));
+        background-color: var(--scrollbar-track-hover, var(--scrollbar-track))
     }
     .scrollbar-thin::-webkit-scrollbar-track:active {
-        background-color: var(--scrollbar-track-active, var(--scrollbar-track-hover, var(--scrollbar-track)));
+        background-color: var(--scrollbar-track-active, var(--scrollbar-track-hover, var(--scrollbar-track)))
     }
     .scrollbar-thin::-webkit-scrollbar-thumb {
         background-color: var(--scrollbar-thumb);
-        border-radius: var(--scrollbar-thumb-radius);
+        border-radius: var(--scrollbar-thumb-radius)
     }
     .scrollbar-thin::-webkit-scrollbar-thumb:hover {
-        background-color: var(--scrollbar-thumb-hover, var(--scrollbar-thumb));
+        background-color: var(--scrollbar-thumb-hover, var(--scrollbar-thumb))
     }
     .scrollbar-thin::-webkit-scrollbar-thumb:active {
-        background-color: var(--scrollbar-thumb-active, var(--scrollbar-thumb-hover, var(--scrollbar-thumb)));
+        background-color: var(--scrollbar-thumb-active, var(--scrollbar-thumb-hover, var(--scrollbar-thumb)))
     }
     .scrollbar-thin::-webkit-scrollbar-corner {
         background-color: var(--scrollbar-corner);
-        border-radius: var(--scrollbar-corner-radius);
+        border-radius: var(--scrollbar-corner-radius)
     }
     .scrollbar-thin::-webkit-scrollbar-corner:hover {
-        background-color: var(--scrollbar-corner-hover, var(--scrollbar-corner));
+        background-color: var(--scrollbar-corner-hover, var(--scrollbar-corner))
     }
     .scrollbar-thin::-webkit-scrollbar-corner:active {
-        background-color: var(--scrollbar-corner-active, var(--scrollbar-corner-hover, var(--scrollbar-corner)));
+        background-color: var(--scrollbar-corner-active, var(--scrollbar-corner-hover, var(--scrollbar-corner)))
     }
     .scrollbar-thin {
         scrollbar-width: thin;
+        scrollbar-color: var(--scrollbar-thumb, initial) var(--scrollbar-track, initial)
     }
     .scrollbar-thin::-webkit-scrollbar {
         display: block;
         width: 8px;
-        height: 8px;
+        height: 8px
     }"
   `);
 });
@@ -125,6 +121,143 @@ test('it generates .scrollbar-none utilities', async () => {
         display: none;
     }"
   `);
+});
+
+describe('it limits scrollbar properties to Firefox when pseudoelements are preferred', () => {
+  test('for scrollbar', async () => {
+    const css = await generatePluginCss({
+      content: [{
+        raw: `
+          <div class="scrollbar" />
+        `
+      }]
+    }, {
+      preferredStrategy: 'pseudoelements'
+    });
+
+    expect(css).toMatchInlineSnapshot(`
+    ".scrollbar::-webkit-scrollbar-track {
+        background-color: var(--scrollbar-track);
+        border-radius: var(--scrollbar-track-radius)
+    }
+    .scrollbar::-webkit-scrollbar-track:hover {
+        background-color: var(--scrollbar-track-hover, var(--scrollbar-track))
+    }
+    .scrollbar::-webkit-scrollbar-track:active {
+        background-color: var(--scrollbar-track-active, var(--scrollbar-track-hover, var(--scrollbar-track)))
+    }
+    .scrollbar::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb);
+        border-radius: var(--scrollbar-thumb-radius)
+    }
+    .scrollbar::-webkit-scrollbar-thumb:hover {
+        background-color: var(--scrollbar-thumb-hover, var(--scrollbar-thumb))
+    }
+    .scrollbar::-webkit-scrollbar-thumb:active {
+        background-color: var(--scrollbar-thumb-active, var(--scrollbar-thumb-hover, var(--scrollbar-thumb)))
+    }
+    .scrollbar::-webkit-scrollbar-corner {
+        background-color: var(--scrollbar-corner);
+        border-radius: var(--scrollbar-corner-radius)
+    }
+    .scrollbar::-webkit-scrollbar-corner:hover {
+        background-color: var(--scrollbar-corner-hover, var(--scrollbar-corner))
+    }
+    .scrollbar::-webkit-scrollbar-corner:active {
+        background-color: var(--scrollbar-corner-active, var(--scrollbar-corner-hover, var(--scrollbar-corner)))
+    }
+    @supports (-moz-appearance:none) {
+        .scrollbar {
+            scrollbar-width: auto;
+            scrollbar-color: var(--scrollbar-thumb, initial) var(--scrollbar-track, initial)
+        }
+    }
+    .scrollbar::-webkit-scrollbar {
+        display: block;
+        width: var(--scrollbar-width, 16px);
+        height: var(--scrollbar-height, 16px)
+    }"
+  `);
+  });
+
+  test('for scrollbar-thin', async () => {
+    const css = await generatePluginCss({
+      content: [{
+        raw: `
+          <div class="scrollbar-thin" />
+        `
+      }]
+    }, {
+      preferredStrategy: 'pseudoelements'
+    });
+
+    expect(css).toMatchInlineSnapshot(`
+    ".scrollbar-thin::-webkit-scrollbar-track {
+        background-color: var(--scrollbar-track);
+        border-radius: var(--scrollbar-track-radius)
+    }
+    .scrollbar-thin::-webkit-scrollbar-track:hover {
+        background-color: var(--scrollbar-track-hover, var(--scrollbar-track))
+    }
+    .scrollbar-thin::-webkit-scrollbar-track:active {
+        background-color: var(--scrollbar-track-active, var(--scrollbar-track-hover, var(--scrollbar-track)))
+    }
+    .scrollbar-thin::-webkit-scrollbar-thumb {
+        background-color: var(--scrollbar-thumb);
+        border-radius: var(--scrollbar-thumb-radius)
+    }
+    .scrollbar-thin::-webkit-scrollbar-thumb:hover {
+        background-color: var(--scrollbar-thumb-hover, var(--scrollbar-thumb))
+    }
+    .scrollbar-thin::-webkit-scrollbar-thumb:active {
+        background-color: var(--scrollbar-thumb-active, var(--scrollbar-thumb-hover, var(--scrollbar-thumb)))
+    }
+    .scrollbar-thin::-webkit-scrollbar-corner {
+        background-color: var(--scrollbar-corner);
+        border-radius: var(--scrollbar-corner-radius)
+    }
+    .scrollbar-thin::-webkit-scrollbar-corner:hover {
+        background-color: var(--scrollbar-corner-hover, var(--scrollbar-corner))
+    }
+    .scrollbar-thin::-webkit-scrollbar-corner:active {
+        background-color: var(--scrollbar-corner-active, var(--scrollbar-corner-hover, var(--scrollbar-corner)))
+    }
+    @supports (-moz-appearance:none) {
+        .scrollbar-thin {
+            scrollbar-width: thin;
+            scrollbar-color: var(--scrollbar-thumb, initial) var(--scrollbar-track, initial)
+        }
+    }
+    .scrollbar-thin::-webkit-scrollbar {
+        display: block;
+        width: 8px;
+        height: 8px
+    }"
+  `);
+  });
+
+  test('for scrollbar-none', async () => {
+    const css = await generatePluginCss({
+      content: [{
+        raw: `
+          <div class="scrollbar-none" />
+        `
+      }]
+    }, {
+      preferredStrategy: 'pseudoelements'
+    });
+
+    expect(css).toMatchInlineSnapshot(`
+    "@supports (-moz-appearance:none) {
+        .scrollbar-none {
+            scrollbar-width: none
+        }
+    }
+    .scrollbar-none::-webkit-scrollbar {
+        display: none
+    }"
+  `);
+  });
 });
 
 test('it generates scrollbar track utilities', async () => {

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -32,7 +32,7 @@ module.exports = {
 
 ### `nocompatible`
 
-By default, only utilities that can have expressions across browsers are available. In order to access additional utilities that may not exist in all browsers, like [rounding](/examples#rounded-bars) and [custom sizes](/examples#custom-sizes), you can add the `nocompatible` flag to the configuration.
+By default, only utilities that can have expressions across browsers are available. In order to access additional utilities that may not exist in all browsers, like [rounding](/examples#rounded-bars) and [custom sizes](/examples#custom-sizes), you can add the `nocompatible` flag to the configuration. You may need to also set the [preferred strategy](#preferredstrategy) to `pseudoelements` for `nocompatible` utilities to take effect in newer browsers.
 
 ```javascript
 module.exports = {

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -30,6 +30,8 @@ module.exports = {
 
 ## Configuration
 
+### `nocompatible`
+
 By default, only utilities that can have expressions across browsers are available. In order to access additional utilities that may not exist in all browsers, like [rounding](/examples#rounded-bars) and [custom sizes](/examples#custom-sizes), you can add the `nocompatible` flag to the configuration.
 
 ```javascript
@@ -38,6 +40,20 @@ module.exports = {
     plugins: [
         // ...
         require('tailwind-scrollbar')({ nocompatible: true }),
+    ],
+};
+```
+
+### `preferredStrategy`
+
+The default scrollbar strategy used by the plugin is to prefer the standards-track properties (`scrollbar-width` and `scrollbar-color`) and fall back to pseudoelements only when standards-track properties are not supported. Although this strategy is encouraged, it does have drawbacks: available features are limited compared to the pseudoelement strategy, and some browser/OS combinations ignore scrollbar properties entirely. If you'd prefer to default to the pseudoelement strategy instead, pass `preferredStrategy: 'pseudoelements'` to the plugin configuration. Note that since Firefox does not support pseudoelements at all, it will continue to use standards-track properties.
+
+```javascript
+module.exports = {
+    // ...
+    plugins: [
+        // ...
+        require('tailwind-scrollbar')({ preferredStrategy: 'pseudoelements' }),  // default: 'standard'
     ],
 };
 ```

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -9,9 +9,7 @@ sidebar_position: 1
 
 ## Motivation
 
-There are currently two competing standards for styling scrollbars amongst browsers: the [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) and [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) properties used by Firefox and the [::-webkit-scrollbar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) family of pseudoelements used by everything else\*. This plugin defines a single API for configuring both standards at once from within Tailwind.
-
-_\* As of Chrome v118, `scrollbar-width` and `scrollbar-color` are now supported with the `#enable-experimental-web-platform-features` flag._
+There are currently two competing standards for styling scrollbars amongst browsers: the [scrollbar-width](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) and [scrollbar-color](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) properties used by Firefox and newer Chromium-based browsers, and the [::-webkit-scrollbar](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar) family of pseudoelements used by everything else. This plugin defines a single API for configuring both standards at once from within Tailwind.
 
 ### What this plugin isn't
 

--- a/website/tailwind.config.js
+++ b/website/tailwind.config.js
@@ -24,7 +24,8 @@ module.exports = {
   },
   plugins: [
     require('tailwind-scrollbar')({
-      nocompatible: true
+      nocompatible: true,
+      preferredStrategy: 'pseudoelements'
     }),
     require('tailwindcss/plugin')(({ addVariant }) => {
       addVariant('self-dark', '[data-theme="dark"]&');


### PR DESCRIPTION
Adds a `preferredStrategy` option to the plugin which allows authors to specify that pseudoelement scrollbars should be used wherever possible, and standards-track `scrollbar-width` and `scrollbar-height` should only be used when the browser (i.e. Firefox) doesn't support pseudoelements.

Should resolve #91.