### PR TITLE
Add support for 'scrollbarColor' theme property

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -122,9 +122,9 @@ const generateScrollbarSizeUtilities = ({ preferPseudoElements }) => ({
  * @param {typedefs.TailwindPlugin} tailwind - Tailwind's plugin object
  */
 const addColorUtilities = ({ matchUtilities, theme }) => {
-  const themeColors = flattenColorPalette(theme('colors'));
+  const themeColors = theme('scrollbarColor') ?? theme('colors');
   const colors = Object.fromEntries(
-    Object.entries(themeColors).map(([k, v]) => [k, toColorValue(v)])
+    Object.entries(flattenColorPalette(themeColors)).map(([k, v]) => [k, toColorValue(v)])
   );
 
   COMPONENTS.forEach(component => {


### PR DESCRIPTION
Currently the plugin only pulls colors from the global "colors" theme property; it would be nice to be able to specify scrollbar-specific colors via its own theme color property, labelled `scrollbarColor`. This is the norm for all other color-related utilities; eg. you can specify utility-specific color palettes under `theme.textColor`, `theme.borderColor`, etc... so this PR adds support for this. If you don't specify a scrollbar-specific color palette, it falls back to the global "colors" -- so this PR doesn't introduce any breaking changes.