### PR TITLE
Account for data variants

### DIFF
--- a/src/variants.d.ts
+++ b/src/variants.d.ts
@@ -23,5 +23,5 @@ export type VariantOverride = {
  *
  * @param {typedefs.TailwindPlugin} tailwind - Tailwind's plugin object
  */
-export function addVariantOverrides({ addVariant, config }: typedefs.TailwindPlugin): void;
+export function addVariantOverrides({ addVariant, matchVariant, config }: typedefs.TailwindPlugin): void;
 import typedefs = require("./typedefs");

--- a/src/variants.js
+++ b/src/variants.js
@@ -66,7 +66,7 @@ const getScrollbarFormat = (variant, config) => {
  *
  * @param {typedefs.TailwindPlugin} tailwind - Tailwind's plugin object
  */
-const addVariantOverrides = ({ addVariant, config }) => {
+const addVariantOverrides = ({ addVariant, matchVariant, config }) => {
   variants.forEach(variant => {
     addVariant(variant, ({ container }) => {
       const suffix = `-${variant}`;
@@ -89,6 +89,12 @@ const addVariantOverrides = ({ addVariant, config }) => {
       return getDefaultFormat(variant, config);
     });
   });
+
+  // The reordering also affects matched variants, such as the built in data-
+  // variant. Regenerating the match causes the variant to be put back to where
+  // it should be. It's quite possible that there are other classes of variants
+  // that should be here, too.
+  matchVariant('data', value => `&[data-${value}]`);
 };
 
 module.exports = {

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -796,3 +796,16 @@ test('it preserves the order of variants', async () => {
 
   expect(pluginCss).toBe(normalCss);
 });
+
+test('it preserves the order of data- variants', async () => {
+  const content = [{
+    raw: `
+      <button class="focus:outline-none data-[focus]:outline data-[focus]:outline-2 data-[focus]:outline-offset-2 data-[focus]:outline-yellow-500" />
+    `
+  }];
+
+  const pluginCss = await generatePluginCss({ content });
+  const normalCss = await generateTailwindCss({ content });
+
+  expect(pluginCss).toBe(normalCss);
+});


### PR DESCRIPTION
Ensures that `data-` variants retain their orderings relative to other variants. Should close #101.