### PR TITLE
Fix some errors with Tailwind CSS v4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "node": ">=12.13.0"
       },
       "peerDependencies": {
-        "tailwindcss": "3.x"
+        "tailwindcss": "4.x || 3.x"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "src/*"
   ],
   "peerDependencies": {
-    "tailwindcss": "3.x"
+    "tailwindcss": "4.x || 3.x"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,12 +1,10 @@
 const flattenColorPaletteImport = require('tailwindcss/lib/util/flattenColorPalette');
-const toColorValueImport = require('tailwindcss/lib/util/toColorValue');
 const typedefs = require('./typedefs');
 const { importDefault } = require('./helpers');
 
 // Tailwind Play will import these internal imports as ES6 imports, while most
 // other workflows will import them as CommonJS imports.
 const flattenColorPalette = importDefault(flattenColorPaletteImport);
-const toColorValue = importDefault(toColorValueImport);
 
 const COMPONENTS = ['track', 'thumb', 'corner'];
 
@@ -115,6 +113,14 @@ const generateScrollbarSizeUtilities = ({ preferPseudoElements }) => ({
     }
   }
 });
+
+/**
+ * Converts a color value or function to a color value
+ *
+ * @param {string | Function} maybeFunction - The color value or function
+ * @returns {string} - The color value
+ */
+const toColorValue = maybeFunction => (typeof maybeFunction === 'function' ? maybeFunction({}) : maybeFunction);
 
 /**
  * Adds scrollbar-COMPONENT-COLOR utilities for every scrollbar component.

--- a/src/variants.js
+++ b/src/variants.js
@@ -1,12 +1,21 @@
 const typedefs = require('./typedefs');
 
+let featureFlagsAvailable = true;
+
 const { flagEnabled } = (() => {
+  // from tailwind v4, featureFlags is not exist
   try {
-    // from tailwind v4, featureFlags is not exist
+    // with tailwind v3
     // eslint-disable-next-line global-require
     return require('tailwindcss/lib/featureFlags');
-  } catch {
-    return {};
+  } catch (e) {
+    // with tailwind v4
+    if (e instanceof Error && e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      featureFlagsAvailable = false;
+      return {};
+    }
+    // unknown error
+    throw e;
   }
 })();
 
@@ -39,8 +48,14 @@ const variants = [
  * @returns {string} The variant format string
  */
 const getDefaultFormat = (variant, config) => {
-  if (variant === 'hover' && flagEnabled && flagEnabled(config(), 'hoverOnlyWhenSupported')) {
-    return '@media (hover: hover) and (pointer: fine) { &:hover }';
+  if (variant === 'hover') {
+    if (!featureFlagsAvailable) {
+      return '@media (hover: hover) { &:hover }';
+    }
+
+    if (flagEnabled && flagEnabled(config(), 'hoverOnlyWhenSupported')) {
+      return '@media (hover: hover) and (pointer: fine) { &:hover }';
+    }
   }
 
   return `&:${variant}`;
@@ -55,8 +70,14 @@ const getDefaultFormat = (variant, config) => {
  * @returns {string} The variant format string
  */
 const getScrollbarFormat = (variant, config) => {
-  if (variant === 'hover' && flagEnabled && flagEnabled(config(), 'hoverOnlyWhenSupported')) {
-    return '@media (hover: hover) and (pointer: fine) { & }';
+  if (variant === 'hover') {
+    if (!featureFlagsAvailable) {
+      return '@media (hover: hover) { & }';
+    }
+
+    if (flagEnabled && flagEnabled(config(), 'hoverOnlyWhenSupported')) {
+      return '@media (hover: hover) and (pointer: fine) { & }';
+    }
   }
 
   return '&';

--- a/src/variants.js
+++ b/src/variants.js
@@ -1,7 +1,14 @@
-// This import doesn't work on Tailwind Play. Move to typescript might fix it
-// on its own, so for now, we just won't check flags on Tailwind Play.
-const { flagEnabled } = require('tailwindcss/lib/featureFlags');
 const typedefs = require('./typedefs');
+
+const { flagEnabled } = (() => {
+  try {
+    // from tailwind v4, featureFlags is not exist
+    // eslint-disable-next-line global-require
+    return require('tailwindcss/lib/featureFlags');
+  } catch {
+    return {};
+  }
+})();
 
 /**
  * @typedef {object} VariantOverride


### PR DESCRIPTION
### issue

resolve #104 

### description

The main fix for this PR is to eliminate errors that occur in tailwindcss v4.

The following changes were made.
- added `toColorValue` to `utilities.js` since `toColorValue` in tailwindcss was removed.
- since `featureFlags` in tailwindcss is probably gone, `require` is now enclosed in `try-catch` to support both versions.
- changed peerDependencies to `4.x || 3.x`.

Confirmed to work with `tailwindcss@4.0.0-beta.7` in the environment at hand
