### PR TITLE
Recognize preferredstrategy as preferredStrategy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const {
 const { addVariants } = require('./variants');
 
 module.exports = plugin.withOptions((options = {}) => tailwind => {
-  let preferredStrategy = options.preferredStrategy ?? 'standard';
+  let preferredStrategy = options.preferredStrategy ?? options.preferredstrategy ?? 'standard';
 
   if (preferredStrategy !== 'standard' && preferredStrategy !== 'pseudoelements') {
     // eslint-disable-next-line no-console

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -192,6 +192,31 @@ describe('it limits scrollbar properties to Firefox when pseudoelements are pref
     }"
   `);
   });
+
+  test('as lowercase', async () => {
+    const css = await generatePluginCss('scrollbar-none.html', {
+      pluginOptions: '{ preferredstrategy: "pseudoelements" }'
+    });
+
+    expect(css).toMatchInlineSnapshot(`
+    ".scrollbar-none {
+      @supports (-moz-appearance:none) {
+        scrollbar-width: none;
+      }
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+    @layer base {
+      * {
+        @supports (-moz-appearance:none) {
+          scrollbar-color: initial;
+          scrollbar-width: initial;
+        }
+      }
+    }"
+  `);
+  });
 });
 
 test('it generates scrollbar track utilities', async () => {


### PR DESCRIPTION
A side effect of Tailwind's move to a CSS-based config file is that configuration parameters need to play by CSS conventions, instead of JavaScript ones. Since it's common to ban camel case from CSS, it seems prudent to recognize all lowercase `preferredstrategy` as meaning the same thing as `preferredStrategy`.

Resolves #109.