### PR TITLE
Adds standalone bundle for CLI usage

### DIFF
--- a/.github/workflows/publish-standalone-bundle.yml
+++ b/.github/workflows/publish-standalone-bundle.yml
@@ -1,0 +1,41 @@
+name: Publish Standalone Bundle
+
+on:
+  release:
+    types:
+      - published
+
+permissions:
+  contents: write
+
+jobs:
+  upload-bundle:
+    name: Upload standalone bundle
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [22.x]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build standalone bundle
+        run: npm run build-bundle
+
+      - name: Upload standalone bundle asset
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          overwrite_files: true
+          files: |
+            bundle/tailwind-scrollbar.mjs

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,12 @@ jobs:
         run: |
           npm ci
 
+      - name: Build standalone bundle
+        run: npm run build-bundle
+
+      - name: Verify standalone bundle is up to date
+        run: git diff --exit-code -- bundle/tailwind-scrollbar.mjs
+
       - name: Lint code
         run: npm run lint
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,33 @@ pnpm add -D tailwind-scrollbar
 @plugin 'tailwind-scrollbar';
 ```
 
+## Standalone CLI (No Node.js)
+
+If you are using Tailwind CSS standalone CLI, download the prebuilt plugin bundle:
+
+```bash
+curl -sLO https://github.com/adoxography/tailwind-scrollbar/releases/latest/download/tailwind-scrollbar.mjs
+```
+
+Then reference it from your input CSS:
+
+```css
+@import 'tailwindcss';
+
+@source not './tailwind-scrollbar.mjs';
+
+@plugin './tailwind-scrollbar.mjs';
+```
+
+Plugin options work the same way:
+
+```css
+@plugin './tailwind-scrollbar.mjs' {
+  nocompatible: true;
+  preferredStrategy: 'pseudoelements';
+}
+```
+
 ## Usage
 See the [documentation](https://adoxography.github.io/tailwind-scrollbar/examples).
 

--- a/bundle/tailwind-scrollbar.mjs
+++ b/bundle/tailwind-scrollbar.mjs
@@ -1,0 +1,260 @@
+/**
+ * @license MIT
+ * tailwind-scrollbar v4.0.2
+ * https://github.com/adoxography/tailwind-scrollbar
+ */
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+
+// node_modules/tailwindcss/dist/plugin.js
+var require_plugin = __commonJS({
+  "node_modules/tailwindcss/dist/plugin.js"(exports, module) {
+    "use strict";
+    function u(i, n) {
+      return { handler: i, config: n };
+    }
+    u.withOptions = function(i, n = () => ({})) {
+      function t(o) {
+        return { handler: i(o), config: n(o) };
+      }
+      return t.__isOptionsFunction = true, t;
+    };
+    var g = u;
+    module.exports = g;
+  }
+});
+
+// node_modules/tailwindcss/dist/flatten-color-palette.js
+var require_flatten_color_palette = __commonJS({
+  "node_modules/tailwindcss/dist/flatten-color-palette.js"(exports, module) {
+    "use strict";
+    function n(r) {
+      let i = {};
+      for (let [e, t] of Object.entries(r ?? {})) if (e !== "__CSS_VALUES__") if (typeof t == "object" && t !== null) for (let [s, l] of Object.entries(n(t))) i[`${e}${s === "DEFAULT" ? "" : `-${s}`}`] = l;
+      else i[e] = t;
+      if ("__CSS_VALUES__" in r) for (let [e, t] of Object.entries(r.__CSS_VALUES__)) Number(t) & 4 || (i[e] = r[e]);
+      return i;
+    }
+    module.exports = n;
+  }
+});
+
+// src/typedefs.js
+var require_typedefs = __commonJS({
+  "src/typedefs.js"(exports) {
+    exports.unused = {};
+  }
+});
+
+// src/helpers.js
+var require_helpers = __commonJS({
+  "src/helpers.js"(exports, module) {
+    var importDefault = (mod) => mod && mod.__esModule ? mod.default : mod;
+    module.exports = {
+      importDefault
+    };
+  }
+});
+
+// src/utilities.js
+var require_utilities = __commonJS({
+  "src/utilities.js"(exports, module) {
+    var flattenColorPaletteImport = require_flatten_color_palette();
+    var typedefs = require_typedefs();
+    var { importDefault } = require_helpers();
+    var flattenColorPalette = importDefault(flattenColorPaletteImport);
+    var COMPONENTS = ["track", "thumb", "corner"];
+    var scrollbarProperties = (properties, preferPseudoElements) => {
+      if (preferPseudoElements) {
+        return {
+          "@supports (-moz-appearance:none)": properties
+        };
+      }
+      return properties;
+    };
+    var addBaseStyles = ({ addBase }, preferredStrategy) => {
+      addBase({
+        "*": scrollbarProperties({
+          "scrollbar-color": "initial",
+          "scrollbar-width": "initial"
+        }, preferredStrategy === "pseudoelements")
+      });
+    };
+    var generateBaseUtilities = () => ({
+      ...Object.fromEntries(COMPONENTS.map((component) => {
+        const base = `&::-webkit-scrollbar-${component}`;
+        return [
+          [base, {
+            "background-color": `var(--scrollbar-${component})`,
+            "border-radius": `var(--scrollbar-${component}-radius)`
+          }]
+        ];
+      }).flat())
+    });
+    var generateScrollbarSizeUtilities = ({ preferPseudoElements }) => ({
+      ".scrollbar": {
+        ...generateBaseUtilities(),
+        ...scrollbarProperties({
+          "scrollbar-width": "auto",
+          "scrollbar-color": "var(--scrollbar-thumb, initial) var(--scrollbar-track, initial)"
+        }, preferPseudoElements),
+        "&::-webkit-scrollbar": {
+          display: "block",
+          width: "var(--scrollbar-width, 16px)",
+          height: "var(--scrollbar-height, 16px)"
+        }
+      },
+      ".scrollbar-thin": {
+        ...generateBaseUtilities(),
+        ...scrollbarProperties({
+          "scrollbar-width": "thin",
+          "scrollbar-color": "var(--scrollbar-thumb, initial) var(--scrollbar-track, initial)"
+        }, preferPseudoElements),
+        "&::-webkit-scrollbar": {
+          display: "block",
+          width: "8px",
+          height: "8px"
+        }
+      },
+      ".scrollbar-none": {
+        ...scrollbarProperties({
+          "scrollbar-width": "none"
+        }, preferPseudoElements),
+        "&::-webkit-scrollbar": {
+          display: "none"
+        }
+      }
+    });
+    var toColorValue = (maybeFunction) => typeof maybeFunction === "function" ? maybeFunction({}) : maybeFunction;
+    var addColorUtilities = ({ matchUtilities, theme }) => {
+      const themeColors = flattenColorPalette(theme("colors"));
+      const colors = Object.fromEntries(
+        Object.entries(themeColors).map(([k, v]) => [k, toColorValue(v)])
+      );
+      COMPONENTS.forEach((component) => {
+        matchUtilities(
+          {
+            [`scrollbar-${component}`]: (value) => ({
+              [`--scrollbar-${component}`]: toColorValue(value)
+            })
+          },
+          {
+            values: colors,
+            type: "color"
+          }
+        );
+      });
+    };
+    var addRoundedUtilities = ({ theme, matchUtilities }) => {
+      COMPONENTS.forEach((component) => {
+        matchUtilities(
+          {
+            [`scrollbar-${component}-rounded`]: (value) => ({
+              [`--scrollbar-${component}-radius`]: value
+            })
+          },
+          {
+            values: theme("borderRadius")
+          }
+        );
+      });
+    };
+    var addBaseSizeUtilities = ({ addUtilities }, preferredStrategy) => {
+      addUtilities(generateScrollbarSizeUtilities({
+        preferPseudoElements: preferredStrategy === "pseudoelements"
+      }));
+    };
+    var addSizeUtilities = ({ matchUtilities, theme }) => {
+      ["width", "height"].forEach((dimension) => {
+        matchUtilities({
+          [`scrollbar-${dimension[0]}`]: (value) => ({
+            [`--scrollbar-${dimension}`]: value
+          })
+        }, {
+          values: theme(dimension)
+        });
+      });
+    };
+    module.exports = {
+      addBaseStyles,
+      addBaseSizeUtilities,
+      addColorUtilities,
+      addRoundedUtilities,
+      addSizeUtilities
+    };
+  }
+});
+
+// src/variants.js
+var require_variants = __commonJS({
+  "src/variants.js"(exports, module) {
+    var addVariants = ({ addVariant }) => {
+      addVariant("scrollbar-hover", "&::-webkit-scrollbar-thumb:hover");
+      addVariant("scrollbar-track-hover", "&::-webkit-scrollbar-track:hover");
+      addVariant("scrollbar-corner-hover", "&::-webkit-scrollbar-corner:hover");
+      addVariant("scrollbar-active", "&::-webkit-scrollbar-thumb:active");
+      addVariant("scrollbar-track-active", "&::-webkit-scrollbar-track:active");
+    };
+    module.exports = {
+      addVariants
+    };
+  }
+});
+
+// src/index.js
+var require_index = __commonJS({
+  "src/index.js"(exports, module) {
+    var plugin = require_plugin();
+    var {
+      addBaseStyles,
+      addBaseSizeUtilities,
+      addColorUtilities,
+      addRoundedUtilities,
+      addSizeUtilities
+    } = require_utilities();
+    var { addVariants } = require_variants();
+    module.exports = plugin.withOptions((options = {}) => (tailwind) => {
+      let preferredStrategy = options.preferredStrategy ?? options.preferredstrategy ?? "standard";
+      if (preferredStrategy !== "standard" && preferredStrategy !== "pseudoelements") {
+        console.warn("WARNING: tailwind-scrollbar preferredStrategy should be 'standard' or 'pseudoelements'");
+        preferredStrategy = "standard";
+      }
+      addBaseStyles(tailwind, preferredStrategy);
+      addBaseSizeUtilities(tailwind, preferredStrategy);
+      addColorUtilities(tailwind);
+      addVariants(tailwind);
+      if (options.nocompatible) {
+        addRoundedUtilities(tailwind);
+        addSizeUtilities(tailwind);
+      }
+    });
+  }
+});
+export default require_index();
+
+/*
+MIT License
+
+Copyright (c) Graham Still <gstill92@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.0.0",
         "cross-env": "^7.0.3",
+        "esbuild": "^0.27.0",
         "eslint": "^8.23.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.23.3",
@@ -19,6 +20,7 @@
         "husky": "^8.0.1",
         "jest": "^29.0.1",
         "postcss": "^8.2.4",
+        "tailwindcss": "^4.0.0",
         "typescript": "^5.0.4"
       },
       "engines": {
@@ -526,6 +528,448 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2694,6 +3138,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -6411,7 +6897,8 @@
     "node_modules/tailwindcss": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.1.tgz",
-      "integrity": "sha512-UK5Biiit/e+r3i0O223bisoS5+y7ZT1PM8Ojn0MxRHzXN1VPZ2KY6Lo6fhu1dOfCfyUAlK7Lt6wSxowRabATBw=="
+      "integrity": "sha512-UK5Biiit/e+r3i0O223bisoS5+y7ZT1PM8Ojn0MxRHzXN1VPZ2KY6Lo6fhu1dOfCfyUAlK7Lt6wSxowRabATBw==",
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
   "license": "MIT",
   "private": false,
   "scripts": {
+    "build-bundle": "node scripts/build-bundle.js",
     "build-types": "rm src/*.d.ts && tsc",
     "lint": "eslint src",
     "prepare": "husky install",
     "test": "jest"
   },
   "files": [
-    "src/*"
+    "src/*",
+    "bundle/*"
   ],
   "peerDependencies": {
     "tailwindcss": "4.x"
@@ -23,6 +25,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",
     "cross-env": "^7.0.3",
+    "esbuild": "^0.27.0",
     "eslint": "^8.23.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.23.3",
@@ -31,6 +34,7 @@
     "husky": "^8.0.1",
     "jest": "^29.0.1",
     "postcss": "^8.2.4",
+    "tailwindcss": "^4.0.0",
     "typescript": "^5.0.4"
   },
   "engines": {

--- a/scripts/build-bundle.js
+++ b/scripts/build-bundle.js
@@ -1,0 +1,62 @@
+const path = require('node:path');
+const { mkdirSync } = require('node:fs');
+const esbuild = require('esbuild');
+const { version } = require('../package.json');
+
+const BANNER = `/**
+ * @license MIT
+ * tailwind-scrollbar v${version}
+ * https://github.com/adoxography/tailwind-scrollbar
+ */`;
+const FOOTER = `
+/*
+MIT License
+
+Copyright (c) Graham Still <gstill92@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+`;
+
+async function buildBundle() {
+  const outdir = path.resolve(__dirname, '../bundle');
+
+  mkdirSync(outdir, { recursive: true });
+
+  await esbuild.build({
+    entryPoints: [path.resolve(__dirname, '../src/index.js')],
+    outfile: path.resolve(outdir, 'tailwind-scrollbar.mjs'),
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    legalComments: 'inline',
+    banner: {
+      js: BANNER
+    },
+    footer: {
+      js: FOOTER
+    }
+  });
+}
+
+buildBundle().catch(error => {
+  // eslint-disable-next-line no-console
+  console.error(error);
+  process.exit(1);
+});

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -47,6 +47,33 @@ The lastest version of `tailwind-scrollbar` (v4) is only compatible with `tailwi
     </TabItem>
 </Tabs>
 
+### Standalone CLI (No Node.js)
+
+If you're using Tailwind's standalone executable, download the prebuilt plugin bundle from the latest release:
+
+```bash
+curl -sLO https://github.com/adoxography/tailwind-scrollbar/releases/latest/download/tailwind-scrollbar.mjs
+```
+
+Then load it directly from your CSS:
+
+```css
+@import 'tailwindcss';
+
+@source not './tailwind-scrollbar.mjs';
+
+@plugin './tailwind-scrollbar.mjs';
+```
+
+You can pass plugin options the same way:
+
+```css
+@plugin './tailwind-scrollbar.mjs' {
+    nocompatible: true;
+    preferredStrategy: 'pseudoelements';
+}
+```
+
 ## Configuration
 
 ### `nocompatible`


### PR DESCRIPTION
## Summary

This PR adds support for using tailwind-scrollbar with Tailwind CSS’s standalone CLI by introducing a pre-built standalone bundle.

## What Changed

- Added a pre-built bundle at `bundle/tailwind-scrollbar.mjs`.
- Added `scripts/build-bundle.js` and wired it into npm scripts.
- Added a release workflow `.github/workflows/publish-standalone-bundle.yml` to automatically publish the standalone bundle on release.
- Updated test workflow `.github/workflows/run-tests.yml` to verify the committed bundle is up-to-date.
- Updated docs `README.md` and `website/docs/getting-started.md` with standalone CLI usage guidance.
- Updated package metadata/dependencies as needed for bundle generation and distribution.

## Why

Users running Tailwind via the standalone CLI (without a Node.js project/runtime) can now use this plugin directly, with CI safeguards to keep the distributed bundle in sync with source changes.

## Testing

```
npm run lint
npm test
npm run build-types
```

## Breaking Changes

None expected.